### PR TITLE
Change require version to avoid breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Lumen bridge for lucadegasperi/oauth2-server-laravel.
 
 ### Via composer
 
-Run ```composer require optimus/oauth2-server-lumen ~0.1```
+Run ```composer require optimus/oauth2-server-lumen 0.1.*```
 
 ### Register package
 


### PR DESCRIPTION
Using a ~0.1 means it will update to 0.2, 0.3 etc. As it's a pre 1.x release breaking changes could happen at the minor version number (e.g. going from 0.1 to 0.2). Therefore I'd recommend suggesting the 0.1.\* so only bug fixes are pulled back in, without the potential of breaking changes
