### PR TITLE
Error when migratecommand run without config alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Copy ```vendor/lucadegasperi/oauth2-server-laravel/config/oauth2.php``` to your 
 
 Run ```php artisan migrate --path=vendor/lucadegasperi/oauth2-server-laravel/migrations```
 
+If you get an error saying the Config class can not be found, add ```class_alias('Illuminate\Support\Facades\Config', 'Config');``` to your ```bootstrap/app.php``` file and uncomment ```$app->withFacades();``` temporarily to import the migrations.
+
 ## Usage
 
 The package is now installed for Lumen. Usage is the same as with lucadegasperi/oauth2-server-laravel, so I suggest you read 


### PR DESCRIPTION
"Fatal error: Class 'Config' not found in ...\vendor\lucadegasperi\oauth2-server-laravel\src\Support\Migration.php on line 32"

Adding the suggested changes in the bootstrap file fixes the issue, as lumen doesn't specify a Config alias for some reason...
